### PR TITLE
Support Basler camera creation with different types of ID (serial number, user name)

### DIFF
--- a/camera/Basler.py
+++ b/camera/Basler.py
@@ -105,9 +105,19 @@ class BaslerClass(PyTango.DeviceClass):
     class_property_list = {}
 
     device_property_list = {
+        # define one and only one of the following 4 properties:
+        'camera_id':
+        [PyTango.DevString,
+         "Camera ID", None],
         'cam_ip_address':
         [PyTango.DevString,
          "Camera ip address",[]],
+        'serial_number':
+        [PyTango.DevString,
+         "Camera serial number", None],
+        'user_name':
+        [PyTango.DevString,
+         "Camera user name", None],
         'inter_packet_delay':
         [PyTango.DevLong,
          "Inter Packet Delay",0],
@@ -143,14 +153,29 @@ _BaslerInterface = None
 # correspond to the MTU, see README file under Pylon-3.2.2 installation
 # directory for for details about network optimization.
 
-def get_control(cam_ip_address = "0", frame_transmission_delay = 0,
-                inter_packet_delay = 0, packet_size = 8000,**keys) :
-    print "cam_ip_address",cam_ip_address
+def get_control(frame_transmission_delay = 0, inter_packet_delay = 0,
+                packet_size = 8000,**keys) :
     global _BaslerCam
     global _BaslerInterface
 
+    if 'camera_id' in keys:
+        camera_id = keys['camera_id']
+    elif 'serial_number' in keys:
+        camera_id = 'sn://' + keys['serial_number']
+    elif 'cam_ip_address' in keys:
+        camera_id = 'ip://' + keys['cam_ip_address']
+    elif 'user_name' in keys:
+        camera_id = 'uname://' + keys['user_name']
+    else:
+        # if no property is present it uses the server personal name
+        # as Basler user name to identify the camera
+        util = PyTango.Util.instance()
+        camera_id = 'uname://' + util.get_ds_inst_name()
+
+    print "basler camera_id:", camera_id
+
     if _BaslerCam is None:
-	_BaslerCam = BaslerAcq.Camera(cam_ip_address,int(packet_size))
+	_BaslerCam = BaslerAcq.Camera(camera_id, int(packet_size))
 	_BaslerCam.setInterPacketDelay(int(inter_packet_delay))
 	_BaslerCam.setFrameTransmissionDelay(int(frame_transmission_delay))
 	_BaslerInterface = BaslerAcq.Interface(_BaslerCam)

--- a/doc/camera/basler.rst
+++ b/doc/camera/basler.rst
@@ -1,3 +1,5 @@
+.. _lima-tango-basler:
+
 Basler Tango device
 =====================
 
@@ -8,13 +10,25 @@ you can also find some useful information about the camera models/prerequisite/i
 Properties
 ----------
 
-======================== =============== =============== ==============================================================
-Property name	         Mandatory	 Default value	 Description
-======================== =============== =============== ==============================================================
-cam_ip_address	         Yes		 N/A		 The camera's ip or hostname 
-inter_packet_delay       No              0               The inter packet delay
-frame_transmission_delay No              0               The frame transmission delay
-======================== =============== =============== ==============================================================
+======================== =============== ================================= =====================================
+Property name	         Mandatory	 Default value	                   Description
+======================== =============== ================================= =====================================
+camera_id                No              uname://*<server instance name>*  The camera ID (see details below)
+inter_packet_delay       No              0                                 The inter packet delay
+frame_transmission_delay No              0                                 The frame transmission delay
+======================== =============== ================================= =====================================
+
+*camera_id* property identifies the camera in the network. Several types of ID might be given:
+
+* IP/hostname (examples: `ip://192.168.5.2`, `ip://white_beam_viewer1.esrf.fr`)
+* Basler serial number (example: `sn://12345678`)
+* Basler user name (example: `uname://white_beam_viewer1`)
+
+If no *camera_id* is given, it uses the server instance name as the camera user name (example, if your server is 
+called `LimaCCDs/white_beam_viewer1`, the default value for *camera_id* will be `uname://white_beam_viewer1`).
+
+To maintain backward compatibility, the old *cam_ip_address* is still supported but is considered deprecated
+and might disappear in the future.
 
 Both inter_packet_delay and frame_tranmission_delay properties can be used to tune the GiGE performance, for
 more information on how to configure a GiGE Basler camera please refer to the Basler documentation.


### PR DESCRIPTION
Basler camera can be created with different IDs:
- serial_number (use: sn://)
- user_name (use: uname://)
- ip (or hostname) (use ip://). Prefix ip:// is optional
