### PR TITLE
patching attribute names causes SEG FAULT

### DIFF
--- a/EnvHelper.py
+++ b/EnvHelper.py
@@ -393,12 +393,12 @@ def to_tango_object(ct, name_id):
                                         self.__dict__["__name"])
             return PyTango.client._Device, (name,)
 
-    for name, value in patched_members.items():
-        setattr(klass, name, property(*value))
-
     klass.__name__ = ct_klass_name
     ct_tango_map[ct_klass] = klass
-    return klass(ct, name_id)
+    kl = klass(ct, name_id)
+    for name, value in patched_members.items():
+        setattr(kl, name, property(*value))
+    return kl
 
 
 def create_tango_objects(ct_control, name_template):


### PR DESCRIPTION
I've just wanted to start LimaCCDs in Similator mode on my box but when I try to do it
I get SEG FAULT, i.e.

    jkotan@haso228k:~/sources/Lima/applications/tango/python$ git checkout master
    Switched to branch 'master'
    Your branch is up-to-date with 'origin/master'.
    jkotan@haso228k:~/sources/Lima/applications/tango/python$ ./LimaCCDs.py TEST
    ctcontrol.accumulation() = <EnvHelper.CtAccumulation object at 0x7f2c6b050390>
    ctcontrol.acquisition() = <EnvHelper.CtAcquisition object at 0x7f2c6b05fdd0>
    ctcontrol.shutter() = <EnvHelper.CtShutter object at 0x7f2c642a9410>
    Segmentation fault

It looks like attributes are set before class instantiation which maybe risky
and cause in my case SEG FAULT.

Bests,
Jan