### PR TITLE
3 Improvements: Entry points, tango new style classes, start server API

### DIFF
--- a/EnvHelper.py
+++ b/EnvHelper.py
@@ -57,10 +57,7 @@ def get_server_name(argv=None):
     """
     if argv is None:
         argv = sys.argv
-    full_exec_name = argv[0]
-    exec_name = os.path.split(full_exec_name)[-1]
-    exec_name = os.path.splitext(exec_name)[0]
-    return "/".join((exec_name, argv[1]))
+    return 'LimaCCDs/' + argv[1]
 
 def get_device_class_map(server=None, cache=True):
     """

--- a/EnvHelper.py
+++ b/EnvHelper.py
@@ -31,6 +31,12 @@ import functools
 
 import PyTango
 
+try:
+    import pkg_resources
+except ImportError:
+    pkg_resources = None
+
+
 ModDepend = ['Core', 'Espia']
 Debug = 0
 LimaDir = None
@@ -442,3 +448,40 @@ def create_tango_objects(ct_control, name_template):
     tango_ct_map[tango_ct_control_name] = tango_ct_control, tango_object
 
     return server, tango_ct_map
+
+
+def _import(name):
+    __import__(name)
+    return sys.modules[name]
+
+
+def get_entry_point(group, name):
+    # try to find an extension using setuptools entry points
+    if pkg_resources is None:
+        return None
+    entry_points = tuple(pkg_resources.iter_entry_points(group, name))
+    if not entry_points:
+        return None
+    elif len(entry_points) > 1:
+        raise ValueError('found more than one entry point matching {}'.format(name))
+    return entry_points[0]
+
+
+def get_camera_module(name):
+    """Returns the python module for the given camera type"""
+    entry_point = get_entry_point('Lima_tango_camera', name)
+    if entry_point is None:
+        # fallback to search in local camera directory
+        mod_name = 'Lima.Server.camera.{}'.format(name)
+        return _import(mod_name)
+    return entry_point.load()
+
+
+def get_plugin_module(name):
+    """Returns the python module for the given plugin type"""
+    entry_point = get_entry_point('Lima_tango_plugin', name)
+    if entry_point is None:
+        # fallback to search in local plugins directory
+        mod_name = 'Lima.Server.plugins.{}'.format(name)
+        return _import(mod_name)
+    return entry_point.load()

--- a/LimaCCDs.py
+++ b/LimaCCDs.py
@@ -64,6 +64,7 @@ LimaCameraType = None
 from .EnvHelper import get_sub_devices
 from .EnvHelper import get_lima_camera_type, get_lima_device_name
 from .EnvHelper import create_tango_objects
+from .EnvHelper import get_camera_module, get_plugin_module
 from .AttrHelper import get_attr_4u
 from Lima.Server.AttrHelper import getDictKey, getDictValue
 from Lima import Core
@@ -353,7 +354,7 @@ class LimaCCDs(PyTango.Device_4Impl) :
     @Core.DEB_MEMBER_FUNCT
     def delete_device(self) :
         try:
-            m = __import__('Lima.Server.camera.%s' % (self.LimaCameraType),None,None,'Lima.Server.camera.%s' % (self.LimaCameraType))
+            m = get_camera_module(self.LimaCameraType)
         except ImportError:
             pass
         else:
@@ -395,8 +396,7 @@ class LimaCCDs(PyTango.Device_4Impl) :
             pass
         else:
             try:
-                m = __import__('Lima.Server.plugins.%s' % (accThresholdCallbackModule),None,None,
-                               'Lima.Server.plugins.%s' % (accThresholdCallbackModule))
+                m = get_plugin_module(accThresholdCallbackModule)
             except ImportError:
                 deb.Error("Couldn't import plugins.%s" % accThresholdCallbackModule)
             else:
@@ -2479,7 +2479,7 @@ def declare_camera_n_commun_to_tango_world(util) :
         try:
             if LimaCameraType and (module_name != LimaCameraType):
                 continue
-            m = __import__('Lima.Server.camera.%s' % (module_name),None,None,'Lima.Server.camera.%s' % (module_name))
+            m = get_camera_module(module_name)
         except ImportError:
             continue
         else:
@@ -2500,7 +2500,7 @@ def declare_camera_n_commun_to_tango_world(util) :
     warningFlag = False
     for module_name in plugins.__all__:
         try:
-            m = __import__('Lima.Server.plugins.%s' % (module_name),None,None,'Lima.Server.plugins.%s' % (module_name))
+            m = get_plugin_module(module_name)
         except ImportError:
             print ("Warning optional plugin %s can't be load, dependency not satisfied." % module_name)
             warningFlag = True
@@ -2535,7 +2535,7 @@ def export_default_plugins() :
         beamlineName,_,cameraName = masterDeviceName.split('/')
         for module_name in plugins.__all__:
             try:
-                m = __import__('Lima.Server.plugins.%s' % (module_name),None,None,'Lima.Server.plugins.%s' % (module_name))
+                m = get_plugin_module(module_name)
             except ImportError:
                 continue
             else:
@@ -2575,7 +2575,7 @@ def export_ct_control(ct_map):
 def _set_control_ref(ctrl_ref) :
     for module_name in plugins.__all__:
         try:
-            m = __import__('Lima.Server.plugins.%s' % (module_name),None,None,'Lima.Server.plugins.%s' % (module_name))
+            m = get_plugin_module(module_name)
         except ImportError:
             continue
         else:
@@ -2638,9 +2638,8 @@ def _get_control():
     except KeyError:            # wizard mode
         return None
 
-    mod_name = 'Lima.Server.camera.' + camera_type
     try:
-        m = __import__(mod_name, None, None, mod_name)
+        m = get_camera_module(camera_type)
     except ImportError:
         import traceback
         traceback.print_exc()
@@ -2648,12 +2647,16 @@ def _get_control():
         properties = {}
         className2deviceName = get_sub_devices()
         try:
-            _, specificDevice = m.get_tango_specific_class_n_device()
+            class_info = m.get_tango_specific_class_n_device()
         except AttributeError:
             import traceback
             traceback.print_exc()
             pass
         else:
+            if isinstance(class_info, (list, tuple)):
+                _, specificDevice = class_info
+            else:
+                specificDevice = class_info
             typeFlagsNameList = []
             for l in range(verboseLevel + 1):
                 typeFlagsNameList += VerboseLevel2TypeFlags.get(l, [])

--- a/LimaCCDs.py
+++ b/LimaCCDs.py
@@ -2692,10 +2692,13 @@ def _get_control():
 #
 #==================================================================
 verboseLevel = 0
-def main() :
+def main(args=None) :
+    args = list(args or sys.argv)
+    args[0] = 'LimaCCDs'
+
     global verboseLevel
     verboseLevel = 0
-    for option in sys.argv:
+    for option in args:
         if option.startswith('-v'):
             try:
                 verboseLevel = int(option[2:])
@@ -2704,7 +2707,7 @@ def main() :
     pytango_ver = PyTango.__version_info__[:3]
 
     try:
-        py = PyTango.Util(sys.argv)
+        py = PyTango.Util(args)
         py.add_TgClass(LimaCCDsClass,LimaCCDs,'LimaCCDs')
         try:
             declare_camera_n_commun_to_tango_world(py)

--- a/LimaCCDs.py
+++ b/LimaCCDs.py
@@ -2485,11 +2485,15 @@ def declare_camera_n_commun_to_tango_world(util) :
         else:
             try:
                 func = getattr(m,'get_tango_specific_class_n_device')
-                specificClass,specificDevice = func()
+                class_info = func()
             except AttributeError:
                 pass
             else:
-                util.add_TgClass(specificClass,specificDevice,specificDevice.__name__)
+                if isinstance(class_info, (list, tuple)):
+                    specificClass, specificDevice = class_info
+                else:
+                    specificClass, specificDevice = class_info.TangoClassClass, class_info
+                util.add_class(specificClass, specificDevice)
             try:
                 func = getattr(m, 'get_taco_specific_cmd_list_n_proxy_cont')
                 cmd_list, proxy_cont = func()
@@ -2521,8 +2525,12 @@ def declare_camera_n_commun_to_tango_world(util) :
             except AttributeError:
                 continue
             else:
-                specificClass,specificDevice = func()
-                util.add_TgClass(specificClass,specificDevice,specificDevice.__name__)
+                class_info = func()
+                if isinstance(class_info, (list, tuple)):
+                    specificClass, specificDevice = class_info
+                else:
+                    specificClass, specificDevice = class_info.TangoClassClass, class_info
+                util.add_class(specificClass, specificDevice)
     if warningFlag and verboseLevel < 4:
         print ("For more plugins dependency information start server with -v4")
 

--- a/camera/__init__.py
+++ b/camera/__init__.py
@@ -31,5 +31,12 @@ def _init_module() :
                 if subdir:
                     base = '%s.%s' % (subdir,base)
                 __all__.append(base)
+    try:
+        import pkg_resources
+    except ImportError:
+        pass
+    else:
+        __all__ += list(pkg_resources.iter_entry_points('Lima_tango_camera'))
+
 _init_module()
 

--- a/camera/__init__.py
+++ b/camera/__init__.py
@@ -19,9 +19,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 ############################################################################
-__all__ = []
+
 def _init_module() :
     import os
+    cameras = []
     for root,dirs,files in os.walk(__path__[0]) :
         for file_name in files :
             if file_name.startswith('__') : continue
@@ -30,13 +31,14 @@ def _init_module() :
                 subdir = root[len(__path__[0]) + 1:]
                 if subdir:
                     base = '%s.%s' % (subdir,base)
-                __all__.append(base)
+                cameras.append(base)
     try:
         import pkg_resources
     except ImportError:
         pass
     else:
-        __all__ += list(pkg_resources.iter_entry_points('Lima_tango_camera'))
+        cameras += list(pkg_resources.iter_entry_points('Lima_tango_camera'))
+    return cameras
 
-_init_module()
+__all__ = _init_module()
 

--- a/camera/__init__.py
+++ b/camera/__init__.py
@@ -37,7 +37,8 @@ def _init_module() :
     except ImportError:
         pass
     else:
-        cameras += list(pkg_resources.iter_entry_points('Lima_tango_camera'))
+        for ep in pkg_resources.iter_entry_points('Lima_tango_camera'):
+            cameras.append(ep.name)
     return cameras
 
 __all__ = _init_module()

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -19,9 +19,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 ############################################################################
-__all__ = []
+
 def _init_module() :
     import os
+    plugins = []
     for root,dirs,files in os.walk(__path__[0],followlinks=True) :
         for file_name in files :
             if file_name.startswith('__') : continue
@@ -30,13 +31,13 @@ def _init_module() :
                 subdir = root[len(__path__[0]) + 1:]
                 if subdir:
                     base = '%s.%s' % (subdir,base)
-                __all__.append(base)
+                plugins.append(base)
     try:
         import pkg_resources
     except ImportError:
         pass
     else:
-        __all__ += list(pkg_resources.iter_entry_points('Lima_tango_plugin'))
+        plugins += list(pkg_resources.iter_entry_points('Lima_tango_plugin'))
 
-_init_module()
+__all__ = _init_module()
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -37,7 +37,8 @@ def _init_module() :
     except ImportError:
         pass
     else:
-        plugins += list(pkg_resources.iter_entry_points('Lima_tango_plugin'))
+        for ep in pkg_resources.iter_entry_points('Lima_tango_plugin'):
+            plugins.append(ep.name)
 
 __all__ = _init_module()
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -31,5 +31,12 @@ def _init_module() :
                 if subdir:
                     base = '%s.%s' % (subdir,base)
                 __all__.append(base)
+    try:
+        import pkg_resources
+    except ImportError:
+        pass
+    else:
+        __all__ += list(pkg_resources.iter_entry_points('Lima_tango_plugin'))
+
 _init_module()
 


### PR DESCRIPTION
# Motivation

I wrote lima camera module in python (yes, yes I know, shame on me :-).
Instead of attaching it to the Lima project I would like to have it as part of my camera library.

## Entry points

It would be nice if in my project I could register the lima camera as an entry point in my setup.py:

```python
# setup.py
setup(
    name='democam',
    description="Python library for the great Demo camera",
    ...,
    entry_points={
        'Lima_tango_camera': [
            'DemoCam = democam.lima.tango'
        ]
    }
)
```

I propose that Lima tango server recognizes two entry points:

* `Lima_tango_camera`: allows a third-party library to register a new Lima tango camera
* `Lima_tango_plugin`: allows a third-party library to register a new Lima tango plugin

cf1a399 makes this possible.

## Tango new style classes

It would be great if we can write tango camera classes using the new style class (see [here](https://pytango.readthedocs.io/en/stable/server_api/server.html))
Example:
```python
from tango.server import Device, device_property, attribute


class DemoCam(Device):
    host = device_property(dtype=str)

    @attribute(dtype=float, unit='keV')
    def energy(self):
        return 10.23


def get_tango_specific_class_n_device():
    return DemoCam


def get_control(host):
    return ...
```

1d6afb9 makes this possible

## Start LimaCCDs programatically

It would be great if it was possible to start LimaCCDs from python like this:
```python
import Lima.Server.LimaCCDs
Lima.Server.LimaCCDs.main()
```


15aa1b4  makes this possible