### PR TITLE
Make sure Device inherits from the most recent tango API available

### DIFF
--- a/LimaCCDs.py
+++ b/LimaCCDs.py
@@ -128,7 +128,7 @@ def RequiresSystemFeature(feature):
         return unsupported_method
     return method_decorator
 
-class LimaCCDs(PyTango.Device_4Impl) :
+class LimaCCDs(PyTango.LatestDeviceImpl) :
 
     Core.DEB_CLASS(Core.DebModApplication, 'LimaCCDs')
     _debugModuleList = ["None",
@@ -365,7 +365,7 @@ class LimaCCDs(PyTango.Device_4Impl) :
 #    Device constructor
 #------------------------------------------------------------------
     def __init__(self,*args) :
-        PyTango.Device_4Impl.__init__(self,*args)
+        PyTango.LatestDeviceImpl.__init__(self,*args)
         self.__className2deviceName = {}
         self.init_device()
         self.__lima_control = None

--- a/LimaViewer.py
+++ b/LimaViewer.py
@@ -58,7 +58,7 @@ import time
 ## Device States Description
 ## No states for this device
 
-class LimaViewer (PyTango.Device_4Impl):
+class LimaViewer (PyTango.LatestDeviceImpl):
 
     #--------- Add you global variables here --------------------------
     #----- PROTECTED REGION ID(LimaViewer.global_variables) ENABLED START -----#
@@ -68,7 +68,7 @@ class LimaViewer (PyTango.Device_4Impl):
     #----- PROTECTED REGION END -----#  //  LimaViewer.global_variables
 
     def __init__(self,cl, name):
-        PyTango.Device_4Impl.__init__(self,cl,name)
+        PyTango.LatestDeviceImpl.__init__(self,cl,name)
         self.debug_stream("In __init__()")
         #----- PROTECTED REGION ID(LimaViewer.__init__) ENABLED START -----#
         self.ImageType2NumpyType = {

--- a/plugins/BackgroundSubstraction.py
+++ b/plugins/BackgroundSubstraction.py
@@ -63,7 +63,7 @@ class BackgroundSubstractionDeviceServer(BasePostProcess) :
                     import traceback
                     traceback.print_exc()
                     return
-        PyTango.Device_4Impl.set_state(self,state)
+        PyTango.LatestDeviceImpl.set_state(self,state)
 
     def read_delete_dark_after_read(self,attr) :
         attr.set_value(self.__deleteDarkAfterRead)

--- a/plugins/Bpm.py
+++ b/plugins/Bpm.py
@@ -122,7 +122,7 @@ class BpmDeviceServer(BasePostProcess):
                     handler.setSinkTask(self._BVDataTask)
 
 
-        PyTango.Device_4Impl.set_state(self,state)
+        PyTango.LatestDeviceImpl.set_state(self,state)
 
     def init_palette(self):
         greyscale_palette = numpy.zeros((65536,3), dtype=numpy.uint8)

--- a/plugins/FlatField.py
+++ b/plugins/FlatField.py
@@ -51,7 +51,7 @@ class FlatfieldDeviceServer(BasePostProcess) :
                                                     self.FLATFIELD_TASK_NAME,
                                                     self._runLevel)
                 self.__flatFieldTask.setFlatFieldImage(self.__flatFieldImage, self.__normalize)
-        PyTango.Device_4Impl.set_state(self,state)
+        PyTango.LatestDeviceImpl.set_state(self,state)
 
     def setFlatFieldImage(self,filepath) :
         self.__flatFieldImage = getDataFromFile(filepath)

--- a/plugins/LimaTacoCCD.py
+++ b/plugins/LimaTacoCCD.py
@@ -96,7 +96,7 @@ DevErrCcdProcessImage		= DevCcdBase + 13
 #   DevState.FAULT :  ccd is in FAULT, cannot take pictures
 #==================================================================
 
-class LimaTacoCCDs(PyTango.Device_4Impl, object):
+class LimaTacoCCDs(PyTango.LatestDeviceImpl, object):
 
     Core.DEB_CLASS(Core.DebModApplication, 'LimaTacoCCDs')
 
@@ -166,7 +166,7 @@ class LimaTacoCCDs(PyTango.Device_4Impl, object):
 #    Device constructor
 #------------------------------------------------------------------
     def __init__(self,cl, name):
-        PyTango.Device_4Impl.__init__(self,cl,name)
+        PyTango.LatestDeviceImpl.__init__(self,cl,name)
         self.init_device()
         try: 
             self.__bpm_mgr  = processlib.Tasks.BpmManager()

--- a/plugins/LiveViewer.py
+++ b/plugins/LiveViewer.py
@@ -73,7 +73,7 @@ class MyImageAttr(PyTango.ImageAttr):
 ## Device States Description
 ## No states for this device
 
-class LiveViewer (PyTango.Device_4Impl):
+class LiveViewer (PyTango.LatestDeviceImpl):
     Core.DEB_CLASS(Core.DebModApplication, 'LimaCCDs')
 
     attr_Exposure_Time = 1 
@@ -86,7 +86,7 @@ class LiveViewer (PyTango.Device_4Impl):
 #------------------------------------------------------------------
     @Core.DEB_MEMBER_FUNCT
     def __init__(self,cl, name):
-        PyTango.Device_4Impl.__init__(self,cl,name)
+        PyTango.LatestDeviceImpl.__init__(self,cl,name)
         self.init_device()
 
 #------------------------------------------------------------------

--- a/plugins/Mask.py
+++ b/plugins/Mask.py
@@ -53,7 +53,7 @@ class MaskDeviceServer(BasePostProcess) :
                                                self.MASK_TASK_NAME,
                                                self._runLevel)
                 self.__maskTask.setMaskImage(self.__maskImage)
-        PyTango.Device_4Impl.set_state(self,state)
+        PyTango.LatestDeviceImpl.set_state(self,state)
 
     def setMaskImage(self,filepath) :
         self.__maskImage = getDataFromFile(filepath)

--- a/plugins/PeakFinder.py
+++ b/plugins/PeakFinder.py
@@ -75,7 +75,7 @@ class PeakFinderDeviceServer(BasePostProcess) :
                                                     self._runLevel)
             self.__peakFinderMgr.clearCounterStatus()
             
-        PyTango.Device_4Impl.set_state(self,state)
+        PyTango.LatestDeviceImpl.set_state(self,state)
 
 #------------------------------------------------------------------
 #    Read BufferSize attribute

--- a/plugins/Roi2Spectrum.py
+++ b/plugins/Roi2Spectrum.py
@@ -72,7 +72,7 @@ class Roi2spectrumDeviceServer(BasePostProcess) :
                                                       self._runLevel)
             self.__roi2spectrumMgr.clearCounterStatus()
 
-        PyTango.Device_4Impl.set_state(self,state)
+        PyTango.LatestDeviceImpl.set_state(self,state)
 
 #------------------------------------------------------------------
 #    Read BufferSize attribute

--- a/plugins/RoiCounter.py
+++ b/plugins/RoiCounter.py
@@ -90,7 +90,7 @@ class RoiCounterDeviceServer(BasePostProcess) :
                                                     self._runLevel)
             self.__roiCounterMgr.clearCounterStatus()
 
-        PyTango.Device_4Impl.set_state(self,state)
+        PyTango.LatestDeviceImpl.set_state(self,state)
 
 #------------------------------------------------------------------
 #    Read BufferSize attribute

--- a/plugins/Utils.py
+++ b/plugins/Utils.py
@@ -60,11 +60,11 @@ def getDatasFromFile(filepath,fromIndex = 0,toIndex = -1) :
         return returnDatas
 
 
-class BasePostProcess(PyTango.Device_4Impl) :
+class BasePostProcess(PyTango.LatestDeviceImpl) :
 
     def __init__(self,*args) :
         self._runLevel = 0
-        PyTango.Device_4Impl.__init__(self,*args)
+        PyTango.LatestDeviceImpl.__init__(self,*args)
 
     def __getattr__(self,name) :
         if name.startswith('is_') and name.endswith('_allowed') :


### PR DESCRIPTION
@stufisher reported on the PyTango issue tracker a bug concerning Tango device servers he noticed when using Lima (see [here](https://github.com/tango-controls/pytango/issues/311)).

It seems Tango C++ 9.3.x introduced a bug when a Device inherits from Device_4Impl: the server is unable to send events (see [here](https://github.com/tango-controls/cppTango/issues/591)).

This PR prevents Lima from being affected by this bug and at the same time enables Lima to use always the latest tango API available.
