### PR TITLE
Tango event for video_live

### DIFF
--- a/LimaCCDs.py
+++ b/LimaCCDs.py
@@ -582,7 +582,7 @@ class LimaCCDs(PyTango.LatestDeviceImpl) :
                           "last_counter_ready", "last_image_acquired",
                           "last_image_ready", "last_image_saved",
                           "video_last_image", "video_last_image_counter",
-                          "acq_status"]:
+                          "video_live", "acq_status"]:
             attr = attr_list.get_attr_by_name(attr_name)
             attr.set_change_event(True, False)
         
@@ -1556,6 +1556,7 @@ class LimaCCDs(PyTango.LatestDeviceImpl) :
             video.startLive()
         else:
             video.stopLive()
+        self.push_change_event("video_live", video.getLive())
 
     def read_video_exposure(self,attr) :
         video = self.__control.video()


### PR DESCRIPTION
Hi,

For a monitoring tool, the `video_live` attribute could be useful to trig.

This PR allow to emit events for this attribute.

There is maybe better place for the `push_change_event`.